### PR TITLE
Resolve global and local variable naming conflict

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,1 @@
-import latex2sympy
+import latex2sympy2

--- a/latex2sympy2.py
+++ b/latex2sympy2.py
@@ -685,8 +685,8 @@ def convert_atom(atom):
         except (TypeError, ValueError):
             return sympy.Number(s)
     elif atom.DIFFERENTIAL():
-        var = get_differential_var(atom.DIFFERENTIAL())
-        return sympy.Symbol('d' + var.name, real=is_real)
+        diff_var = get_differential_var(atom.DIFFERENTIAL())
+        return sympy.Symbol('d' + diff_var.name, real=is_real)
     elif atom.mathit():
         text = rule2text(atom.mathit().mathit_text())
         return sympy.Symbol(text, real=is_real)
@@ -1035,13 +1035,13 @@ def handle_sum_or_prod(func, name):
 def handle_limit(func):
     sub = func.limit_sub()
     if sub.LETTER_NO_E():
-        var = sympy.Symbol(sub.LETTER_NO_E().getText(), real=is_real)
+        lim_var = sympy.Symbol(sub.LETTER_NO_E().getText(), real=is_real)
     elif sub.GREEK_CMD():
-        var = sympy.Symbol(sub.GREEK_CMD().getText()[1:].strip(), real=is_real)
+        lim_var = sympy.Symbol(sub.GREEK_CMD().getText()[1:].strip(), real=is_real)
     elif sub.OTHER_SYMBOL_CMD():
-        var = sympy.Symbol(sub.OTHER_SYMBOL_CMD().getText().strip(), real=is_real)
+        lim_var = sympy.Symbol(sub.OTHER_SYMBOL_CMD().getText().strip(), real=is_real)
     else:
-        var = sympy.Symbol('x', real=is_real)
+        lim_var = sympy.Symbol('x', real=is_real)
     if sub.SUB():
         direction = "-"
     else:
@@ -1049,7 +1049,7 @@ def handle_limit(func):
     approaching = convert_expr(sub.expr())
     content = convert_mp(func.mp())
 
-    return sympy.Limit(content, var, approaching, direction)
+    return sympy.Limit(content, lim_var, approaching, direction)
 
 
 def handle_exp(func):


### PR DESCRIPTION
There is variable 'var' in functions convert_atom and handle_limit, which, as I understand, should be local. However, it turned out that in convert_atom (latex2sympy2.py, line 688)
```
var = get_differential_var(atom.DIFFERENTIAL())
```
this variable interpreted as global, which causes an error:
```
File C:\Program Files\Python311\Lib\site-packages\latex2sympy2.py:643, in convert_atom(atom)
    641 matrix_symbol = None
    642 global var
--> 643 if atom_text + subscript_text in var:
    644     try:
    645         rh = var[atom_text + subscript_text]

TypeError: argument of type 'Symbol' is not iterable
```
I changed the names of local variables to avoid naming conflict